### PR TITLE
Refactor engine html retrieval

### DIFF
--- a/character.py
+++ b/character.py
@@ -54,7 +54,7 @@ class CharacterSpecialAttacks(object):
 
 class CharacterThrowAttacks(object):
     def __init__(self, moves):
-        self.stand_grab = next(st for st in moves if "stand" in st.name.lower())
+        self.stand_grab = next(st for st in moves if st.name.lower() == "grab")
         self.dash_grab = next(dsh for dsh in moves if "dash" in dsh.name.lower())
         self.pivot_grab = next(pvt for pvt in moves if "pivot" in pvt.name.lower())
         self.pummel = next(pml for pml in moves if "pummel" in pml.name.lower())

--- a/character.py
+++ b/character.py
@@ -118,6 +118,7 @@ class CharacterThrow(CharacterAction):
         # associated methods to this class and derive from the base
         # CharacterAction class. I wanted to derive from the CharacterAttack
         # class below, but this is still just a DTO
+        self.hitbox = throw_dict["hitboximg"]
         self.startup_frames = throw_dict["startup"]
         self.base_damage = throw_dict["basedamage"]
 

--- a/dataparser.py
+++ b/dataparser.py
@@ -18,10 +18,14 @@ class HtmlDataParser(object):
             The inner text of the element as a string
         """
         if element_class_name is None:
-            data = self.html.find(html_element).text
+            data = self.html.find(html_element)
         else:
-            data = self.html.find(html_element, element_class_name).text
-        return data.strip()
+            data = self.html.find(html_element, element_class_name)
+
+        if data is not None:
+            return data.text.strip()
+        else:
+            return None
 
 class AttackDataParser(HtmlDataParser):
     def __init__(self, html):

--- a/scrapeengine.py
+++ b/scrapeengine.py
@@ -6,28 +6,46 @@ from bs4 import BeautifulSoup
 class ScrapeEngine(object):
 
     ufdUrl = 'https://ultimateframedata.com/'
+    html_classes = [
+            "hitboximg", "movename", "startup",
+            "totalframes", "landinglag", "notes",
+            "basedamage", "shieldlag", "shieldstun",
+            "whichhitbox", "advantage", "activeframes"
+    ]
 
     def __init__(self, char_name):
         self.character_name = char_name
 
     def get_page_for_character_name(self):
+        """Retrieves the html for the character's frame data web page
+        
+        Returns:
+            The html of the character's frame data page as a BeautifulSoup object
+        """
         page_data = requests.get('{0}{1}.php'.format(self.ufdUrl, self.character_name))
         return BeautifulSoup(page_data.text, 'lxml')
 
     def get_frame_data(self, page_data):
+        """This function will retrieve the frame data from the html provided by BeautifulSoup
+        
+        Args:
+            page_data: The frame data webpage as a BeautifulSoup object
+        Returns:
+            A Character DTO with the character's name and their frame data
+        """
         # There are 6 sections: ground moves, aerials, specials, throws, dodges, and misc info
         char_moves = page_data.find_all("div", class_="moves")
 
-        ground_data = self.__get_attack_move_frame_data(char_moves[0])
-        aerial_data = self.__get_attack_move_frame_data(char_moves[1])
-        specials_data = self.__get_attack_move_frame_data(char_moves[2])
-        throws_data = self.__get_throws_frame_data(char_moves[3])
-        dodges_data = self.__get_dodges_frame_data(char_moves[4])
+        ground_data = self.__get_action_frame_data(char_moves[0])
+        aerial_data = self.__get_action_frame_data(char_moves[1])
+        specials_data = self.__get_action_frame_data(char_moves[2])
+        throws_data = self.__get_action_frame_data(char_moves[3])
+        dodges_data = self.__get_action_frame_data(char_moves[4])
         misc_data = self.__get_misc_data(char_moves[5])
 
         return dto.Character(self.character_name, ground_data, aerial_data, specials_data, throws_data, dodges_data, misc_data)
 
-    def __get_attack_move_frame_data(self, moves):
+    def __get_action_frame_data(self, moves):
         """Retrieves the ground moves from the character's frame data page
 
         Args:
@@ -44,62 +62,45 @@ class ScrapeEngine(object):
         return move_list   
 
     def __get_move_from_container(self, attack_container):
+        """Extracts the raw data we actually want from the html container
+
+        Returns:
+            A DTO that derives from the base CharacterAction class
+        """
         parser = hdp.AttackDataParser(attack_container)
-        html_classes = [
-            "hitboximg", "movename", "startup",
-            "totalframes", "landinglag", "notes",
-            "basedamage", "shieldlag", "shieldstun",
-            "whichhitbox", "advantage", "activeframes"
-        ]
         parsed_data = {}
-        for c in html_classes:
+        for c in self.html_classes:
             if c == "hitboximg":
                 data = parser.extract_hitbox()
             else:
                 data = parser.get_data_from_element("div", c)
-            parsed_data[c] = data
-        return dto.CharacterAttack(parsed_data)
+            # If the element couldn't be found, skip it and try the next
+            # (This covers elements that BS4 reports as nonexistent 
+            # or empty hitbox visualization lists)
+            if data is None or not data:
+                continue
+            else:
+                parsed_data[c] = data
+        return self.__generate_dto(parsed_data)
 
-    def __get_throws_frame_data(self, throws):
-        throw_html = throws.find_all("div", class_="movecontainer")
-        throw_list = []
-        for throw in throw_html:
-            t = self.__get_throw_from_container(throw)
-            throw_list.append(t)
-        return throw_list
+    def __generate_dto(self, parsed_data_dict):
+        """Return a child DTO based on the parent CharacterAction class based on the
+        number of keys in the parsed data dictionary. The idea is that if there are 4
+        keys, it's the character's dodge, etc.
 
-    def __get_throw_from_container(self, throw_container):
-        parser = hdp.HtmlDataParser(throw_container)
-        html_classes = [
-            "movename", "startup",
-            "totalframes", "landinglag",
-            "notes", "basedamage"
-        ]
-        parsed_data = {}
-        for c in html_classes:
-            data = parser.get_data_from_element("div", c)
-            parsed_data[c] = data
-        return dto.CharacterThrow(parsed_data)       
-
-    def __get_dodges_frame_data(self, dodges):
-        dodge_html = dodges.find_all("div", class_="movecontainer")
-        dodge_list = []
-        for dodge in dodge_html:
-            d = self.__get_dodge_from_container(dodge)
-            dodge_list.append(d)
-        return dodge_list
-
-    def __get_dodge_from_container(self, dodge_container):
-        parser = hdp.HtmlDataParser(dodge_container)
-        html_classes = [
-            "movename", "totalframes",
-            "landinglag", "notes"
-        ]
-        parsed_data = {}
-        for c in html_classes:
-            data = parser.get_data_from_element("div", c)
-            parsed_data[c] = data
-        return dto.CharacterDodge(parsed_data)
+        Returns:
+            The appropriate DTO
+        """
+        keys_in_pdd = len(list(parsed_data_dict.keys()))
+        # A dodge has 4 items: name, total frames, landing lag, and any misc notes
+        if keys_in_pdd == 4:
+            return dto.CharacterDodge(parsed_data_dict)
+        # A throw has 7 items: 4 from the base class, a hitbox visualization,
+        # startup frames, and base damage
+        elif keys_in_pdd == 7:
+            return dto.CharacterThrow(parsed_data_dict)
+        else:
+            return dto.CharacterAttack(parsed_data_dict)
 
     def __get_misc_data(self, misc_attributes):
         return []

--- a/scrapeengine.py
+++ b/scrapeengine.py
@@ -41,35 +41,7 @@ class ScrapeEngine(object):
         for move in move_html:
             m = self.__get_move_from_container(move)
             move_list.append(m)
-        return move_list
-
-    def __get_throws_frame_data(self, throw_container):
-        parser = hdp.HtmlDataParser(throw_container)
-        html_classes = [
-            "movename", "startup",
-            "totalframes", "landinglag",
-            "notes", "basedamage"
-        ]
-        parsed_data = {}
-        for c in html_classes:
-            data = parser.get_data_from_element("div", c)
-            parsed_data[c] = data
-        return dto.CharacterThrow(parsed_data)
-
-    def __get_dodges_frame_data(self, dodge_container):
-        parser = hdp.HtmlDataParser(dodge_container)
-        html_classes = [
-            "movename", "totalframes",
-            "landinglag", "notes"
-        ]
-        parsed_data = {}
-        for c in html_classes:
-            data = parser.get_data_from_element("div", c)
-            parsed_data[c] = data
-        return dto.CharacterDodge(parsed_data)
-
-    def __get_misc_data(self, misc_attributes):
-        return []
+        return move_list   
 
     def __get_move_from_container(self, attack_container):
         parser = hdp.AttackDataParser(attack_container)
@@ -87,3 +59,49 @@ class ScrapeEngine(object):
                 data = parser.get_data_from_element("div", c)
             parsed_data[c] = data
         return dto.CharacterAttack(parsed_data)
+
+    def __get_throws_frame_data(self, throws):
+        throw_html = throws.find_all("div", class_="movecontainer")
+        throw_list = []
+        for throw in throw_html:
+            t = self.__get_throw_from_container(throw)
+            throw_list.append(t)
+        return throw_list
+
+    def __get_throw_from_container(self, throw_container):
+        parser = hdp.HtmlDataParser(throw_container)
+        html_classes = [
+            "movename", "startup",
+            "totalframes", "landinglag",
+            "notes", "basedamage"
+        ]
+        parsed_data = {}
+        for c in html_classes:
+            data = parser.get_data_from_element("div", c)
+            parsed_data[c] = data
+        return dto.CharacterThrow(parsed_data)       
+
+    def __get_dodges_frame_data(self, dodges):
+        dodge_html = dodges.find_all("div", class_="movecontainer")
+        dodge_list = []
+        for dodge in dodge_html:
+            d = self.__get_dodge_from_container(dodge)
+            dodge_list.append(d)
+        return dodge_list
+
+    def __get_dodge_from_container(self, dodge_container):
+        parser = hdp.HtmlDataParser(dodge_container)
+        html_classes = [
+            "movename", "totalframes",
+            "landinglag", "notes"
+        ]
+        parsed_data = {}
+        for c in html_classes:
+            data = parser.get_data_from_element("div", c)
+            parsed_data[c] = data
+        return dto.CharacterDodge(parsed_data)
+
+    def __get_misc_data(self, misc_attributes):
+        return []
+
+


### PR DESCRIPTION
Modified CharacterThrowAttacks DTO based on what I saw during "testing" - list comprehension needed to be changed from "[foo] in name property" to "name property == [foo]"

Added property for hitbox visualization to CharacterThrow DTO

Data parser module will now return `None` if the call to `find()` cannot find the element.

Renamed `__get_attack_move_frame_data()` to `__get_action_frame_data()` to be more in line with the DTOs and DRY up duplicated code, and subsequently deleted duplicated code.

